### PR TITLE
Use authentication from npm

### DIFF
--- a/lib/npm/get-conf.js
+++ b/lib/npm/get-conf.js
@@ -36,8 +36,15 @@ function getGlobalNodeModulesPath() {
 }
 
 function getRegistryClient() {
-    var client = new RegistryClient(npmConfig);
-    return q.nbind(client.get, client);
+    return function (url) {
+        return getConf().then(function (conf) {
+            var regConf = {
+                auth: conf.getCredentialsByURI(url),
+            };
+            var client = new RegistryClient(npmConfig);
+            return q.ninvoke(client, 'get', url, regConf);
+        });
+    };
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes #11.

Might need some work on parameter handling. Currently ignores the passed in params option (although this is `{}` in npm-check at the moment anyway).