### PR TITLE
Fix issue with cursor disappearing on `npm-check -u`.

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -62,7 +62,6 @@ function createChoices(packages, options) {
 
     if (choicesWithTableFormating.length) {
         choices.unshift(unselectable(options));
-        choices.unshift(unselectable());
         return choices;
     }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "depcheck": "^0.4",
     "giturl": "0.0.3",
     "globby": "^1.2.0",
-    "inquirer": "^0.8.0",
+    "inquirer": "^0.9.0",
     "lodash": "^3.3.0",
     "npm-registry-client": "^6.1.1",
     "npmconf": "^2.0",


### PR DESCRIPTION
The extra empty black separator causes the cursor to disappear in additional sections of the updater.