### PR TITLE
fix: TypeError: utils.hideCursor is not a function

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -61,8 +61,8 @@ function outputConsole(modules, options) {
     }
 
     var rows = _(modules).reduce(function (acc, data, moduleName) {
-            return acc.concat(render(moduleName, data));
-        }, []);
+        return acc.concat(render(moduleName, data));
+    }, []);
 
     rows = _(rows)
         .compact()

--- a/lib/process-data.js
+++ b/lib/process-data.js
@@ -94,14 +94,14 @@ function processData(options) {
     return q.allSettled(promises)
         .then(function (dataInPromises) {
             var data = _(dataInPromises).map(function (promiseResult) {
-                    if (promiseResult.state === 'fulfilled') {
-                        return promiseResult.value;
-                    }
-                    console.log('Error running promise: ', promiseResult.reason.stack);
-                })
-                .compact()
-                .indexBy('moduleName')
-                .valueOf();
+                if (promiseResult.state === 'fulfilled') {
+                    return promiseResult.value;
+                }
+                console.log('Error running promise: ', promiseResult.reason.stack);
+            })
+            .compact()
+            .indexBy('moduleName')
+            .valueOf();
 
             return q.resolve(data);
         });

--- a/lib/prompts/alt-checkbox.js
+++ b/lib/prompts/alt-checkbox.js
@@ -16,6 +16,7 @@ var figures = require("figures");
 var Base = require("inquirer/lib/prompts/base");
 var observe = require("inquirer/lib/utils/events");
 var utils = require("inquirer/lib/utils/readline");
+var cliCursor = require("cli-cursor");
 var Paginator = require("./alt-paginator"); // [dylang] Only change in this file
 
 
@@ -77,7 +78,7 @@ Prompt.prototype._run = function( cb ) {
   events.spaceKey.takeUntil( validation.success ).forEach( this.onSpaceKey.bind(this) );
 
   // Init the prompt
-  utils.hideCursor(this.rl);
+  cliCursor.hide();
   this.render();
 
   return this;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "buffered-spawn": "^1.1.2",
     "chalk": "^1.1.0",
+    "cli-cursor": "^1.0.1",
     "commander": "^2.8.1",
     "depcheck": "^0.4.7",
     "figures": "^1.3.5",


### PR DESCRIPTION
- Use cli-cursor module

Fixes #39

See https://github.com/SBoudrias/Inquirer.js/commit/0c8a91391c6a1fcb6017295f0e65c91366ddd06b