### PR TITLE
ES6 support with depcheck-es6

### DIFF
--- a/lib/check-unused.js
+++ b/lib/check-unused.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var q = require('q');
-var depcheck = require('depcheck');
+var depcheck = require('depcheck-es6');
 
 function checkUnused(options) {
     var defer = q.defer();

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "chalk": "^1.1.0",
     "cli-cursor": "^1.0.2",
     "commander": "^2.8.1",
-    "depcheck": "^0.4.7",
+    "depcheck-es6": "^0.5.0",
     "figures": "^1.4.0",
     "giturl": "0.0.3",
     "global-modules": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "chalk": "^1.1.0",
     "cli-cursor": "^1.0.2",
     "commander": "^2.8.1",
-    "depcheck-es6": "^0.5.0",
+    "depcheck-es6": "^0.5.1",
     "figures": "^1.4.0",
     "giturl": "0.0.3",
     "global-modules": "^0.2.0",


### PR DESCRIPTION
If your code has JSX, or uses stuff that acorn or node-soure-walker cannot
parse, such as `static`, then it's still going to say that you haven't included
something.

Not sure what the right course of action is, as this is really sort of an
interesting problem for the parsing libraries that we use.

Anyway, if you're using plain ol' ES6 without anything fancy, this should
resolve your imports for you just fine.

#17 