### PR TITLE
Depcheck-es6 is merged back to depcheck now!

### DIFF
--- a/lib/check-unused.js
+++ b/lib/check-unused.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var q = require('q');
-var depcheck = require('depcheck-es6');
+var depcheck = require('depcheck');
 
 function checkUnused(options) {
     var defer = q.defer();

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "chalk": "^1.1.0",
     "cli-cursor": "^1.0.2",
     "commander": "^2.9.0",
-    "depcheck-es6": "^0.5.5",
+    "depcheck": "^0.5.9",
     "figures": "^1.4.0",
     "giturl": "^1.0.0",
     "global-modules": "^0.2.0",


### PR DESCRIPTION
Hi, @dylang.

@rumpl and I decided to merge depcheck-es6 back to [depcheck](https://github.com/depcheck/depcheck) and move the repo under an organization. I will continue to develop and maintain the project, all new releases will go back to [depcheck package](https://www.npmjs.com/package/depcheck) now.

A new version, 0.5.9, is released on depcheck. Its function is same as depcheck-es6 0.5.8. As said before, the 0.5.x versions will be fully backward compatible with the older versions. No code changes on your side.

The depcheck-es6 package will be deprecated after all dependents migrate to depcheck.

Thanks for understanding!

-Junle