### PR TITLE
Added checking of scoped global packages

### DIFF
--- a/lib/process-data.js
+++ b/lib/process-data.js
@@ -77,7 +77,7 @@ function processData(options) {
     var nodeModulesPath = _.endsWith(options.path, 'node_modules') ? options.path :
         path.join(options.path, 'node_modules');
 
-    var installedPackages = options.global ? globby.sync(path.resolve(nodeModulesPath, '*/package.json')) : false;
+    var installedPackages = options.global ? globby.sync(path.resolve(nodeModulesPath, '{*/package.json,@*/*/package.json}')) : false;
 
     projectPackageJson.installed = _(installedPackages)
         .map(function (pkgPath) {


### PR DESCRIPTION
Running npm-check with -g doesn't currently show scoped packages. This fixes that by checking for global folders that begin with "@" and finding package.json files inside those children