### PR TITLE
Add Metalsmith plugins to list of ignored unused packages

### DIFF
--- a/lib/check-unused.js
+++ b/lib/check-unused.js
@@ -34,7 +34,7 @@ function checkUnused(currentState) {
                 'karma-*',
                 'angular-*',
                 'babel-*',
-                'metalsmith-',
+                'metalsmith-*',
                 'grunt'
             ]
         };

--- a/lib/check-unused.js
+++ b/lib/check-unused.js
@@ -34,6 +34,7 @@ function checkUnused(currentState) {
                 'karma-*',
                 'angular-*',
                 'babel-*',
+                'metalsmith-',
                 'grunt'
             ]
         };


### PR DESCRIPTION
Ignore [Metalsmith](http://www.metalsmith.io) plugins, which can be [loaded en masse](https://github.com/karlbright/load-metalsmith-plugins), similarly to i.e. `gulp`, `karma` and others.