### PR TITLE
add `-i`, `--installer` option. it change to another installer (fix #101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ### On the command line
 
-This is how you should use `npm-check`. 
+This is how you should use `npm-check`.
 
 #### Install
 
@@ -61,7 +61,7 @@ The result should look like the screenshot, or something nice when your packages
 ```
 Usage
   $ npm-check <path> <options>
-  
+
 Path
   Where to check. Defaults to current directory. Use -g for checking global modules.
 
@@ -71,6 +71,7 @@ Options
   -s, --skip-unused     Skip check for unused packages.
   -p, --production      Skip devDependencies.
   -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
+  -i, --installer <npm> Change npm installer. (eg 'pnpm', 'ied')
   --no-color            Force or disable color output.
   --no-emoji            Remove emoji support. No emoji in default in CI environments.
   --debug               Debug output. Throw in a gist when creating issues on github.
@@ -118,20 +119,24 @@ By default `npm-check` will look at packages listed as `dependencies` and `devDe
 This option will let it ignore outdated and unused checks for packages listed as `devDependencies`.
 
 ###### -E, --save-exact
-  
+
 Install packages using `--save-exact`, meaning exact versions will be saved in package.json.
- 
+
 Applies to both `dependencies` and `devDependencies`.
 
+###### -i, --installer <npm>
+
+Change the npm installer, do the update by using the specified installer. (such as [ied](https://github.com/alexanderGugel/ied), [pnpm](https://github.com/rstacruz/pnpm))
+
 ###### --color, --no-color
-  
+
 Enable or disable color support.
 
 By default `npm-check` uses colors if they are available.
 
 ###### --emoji, --no-emoji
-  
-Enable or disable emoji support. Useful for terminals that don't support them. 
+
+Enable or disable emoji support. Useful for terminals that don't support them.
 
 
 
@@ -255,6 +260,6 @@ Released under the [MIT license](https://tldrlegal.com/license/mit-license).
 Screenshots are [CC BY-SA](http://creativecommons.org/licenses/by-sa/4.0/) (Attribution-ShareAlike).
 
 ***
-_Generated using [grunt-readme](https://github.com/assemble/grunt-readme) with [grunt-templates-dylang](https://github.com/dylang/grunt-templates-dylang) on Tuesday, March 29, 2016._
+_Generated using [grunt-readme](https://github.com/assemble/grunt-readme) with [grunt-templates-dylang](https://github.com/dylang/grunt-templates-dylang) on Thursday, March 31, 2016._
 _To make changes to this document look in `/templates/readme/`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -25,6 +25,7 @@ const cli = meow({
           -s, --skip-unused     Skip check for unused packages.
           -p, --production      Skip devDependencies.
           -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
+          -i, --installer <npm> Change npm installer. (eg 'pnpm', 'ied')
           --no-color            Force or disable color output.
           --no-emoji            Remove emoji support. No emoji in default in CI environments.
           --debug               Debug output. Throw in a gist when creating issues on github.
@@ -40,7 +41,8 @@ const cli = meow({
             g: 'global',
             s: 'skip-unused',
             p: 'production',
-            E: 'save-exact'
+            E: 'save-exact',
+            i: 'installer'
         },
         default: {
             dir: process.cwd(),
@@ -64,6 +66,7 @@ const options = {
     skipUnused: cli.flags.skipUnused,
     ignoreDev: cli.flags.production,
     saveExact: cli.flags.saveExact,
+    installer: cli.flags.installer,
     emoji: cli.flags.emoji,
     debug: cli.flags.debug
 };
@@ -78,7 +81,7 @@ npmCheck(options)
         currentState.inspectIfDebugMode();
 
         if (options.update) {
-            return update(currentState);
+            return update(currentState, options.installer);
         }
 
         return output(currentState);

--- a/lib/npm/spawn-npm.js
+++ b/lib/npm/spawn-npm.js
@@ -4,9 +4,12 @@ const chalk = require('chalk');
 const execa = require('execa');
 const ora = require('ora');
 
-function install(packages, currentState) {
+function install(packages, currentState, installer) {
     if (!packages.length) {
         return Promise.resolve(currentState);
+    }
+    if (typeof installer !== 'string') {
+        installer = 'npm';
     }
 
     const installGlobal = currentState.get('global') ? '--global' : null;
@@ -20,14 +23,16 @@ function install(packages, currentState) {
         .concat(color)
         .filter(Boolean);
 
-    const logMessage = `${chalk.green('npm')} ${chalk.green(npmArgs.join(' '))}`;
+    const logMessage = `${chalk.green(installer)} ${chalk.green(npmArgs.join(' '))}`;
     const spinner = ora(logMessage);
     spinner.start();
 
-    return execa('npm', npmArgs, {cwd: currentState.get('cwd')}).then(output => {
+    return execa(installer, npmArgs, {cwd: currentState.get('cwd')}).then(output => {
         spinner.stop();
         console.log(logMessage);
-        console.log(output.stdout);
+        if (installer !== 'pnpm') { // dirty output at pnpm... :(
+            console.log(output.stdout);
+        }
         console.log(output.stderr);
 
         return currentState;

--- a/lib/update.js
+++ b/lib/update.js
@@ -93,7 +93,7 @@ function createChoices(packages, options) {
     }
 }
 
-function interactive(currentState) {
+function interactive(currentState, installer) {
     const packages = currentState.get('packages');
 
     if (currentState.get('debug')) {
@@ -151,7 +151,7 @@ function interactive(currentState) {
         }
 
         return spawnNpm.install(saveDependencies, currentState)
-            .then(currentState => spawnNpm.install(saveDevDependencies, currentState))
+            .then(currentState => spawnNpm.install(saveDevDependencies, currentState, installer))
             .then(currentState => {
                 console.log('');
                 console.log(chalk.green(`[npm-check] Update complete!`));

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -18,6 +18,7 @@ const defaultOptions = {
     ignoreDev: false,
     forceColor: false,
     saveExact: false,
+    installer: 'npm',
     debug: false,
     emoji: true,
 

--- a/templates/readme/cli.md
+++ b/templates/readme/cli.md
@@ -1,6 +1,6 @@
 ## On the command line
 
-This is how you should use `npm-check`. 
+This is how you should use `npm-check`.
 
 ### Install
 
@@ -26,7 +26,7 @@ The result should look like the screenshot, or something nice when your packages
 ```
 Usage
   $ npm-check <path> <options>
-  
+
 Path
   Where to check. Defaults to current directory. Use -g for checking global modules.
 
@@ -36,6 +36,7 @@ Options
   -s, --skip-unused     Skip check for unused packages.
   -p, --production      Skip devDependencies.
   -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
+  -i, --installer <npm> Change npm installer. (eg 'pnpm', 'ied')
   --no-color            Force or disable color output.
   --no-emoji            Remove emoji support. No emoji in default in CI environments.
   --debug               Debug output. Throw in a gist when creating issues on github.
@@ -83,17 +84,21 @@ By default `npm-check` will look at packages listed as `dependencies` and `devDe
 This option will let it ignore outdated and unused checks for packages listed as `devDependencies`.
 
 ##### -E, --save-exact
-  
+
 Install packages using `--save-exact`, meaning exact versions will be saved in package.json.
- 
+
 Applies to both `dependencies` and `devDependencies`.
 
+##### -i, --installer <npm>
+
+Change the npm installer, do the update by using the specified installer. (such as [ied](https://github.com/alexanderGugel/ied), [pnpm](https://github.com/rstacruz/pnpm))
+
 ##### --color, --no-color
-  
+
 Enable or disable color support.
 
 By default `npm-check` uses colors if they are available.
 
 ##### --emoji, --no-emoji
-  
-Enable or disable emoji support. Useful for terminals that don't support them. 
+
+Enable or disable emoji support. Useful for terminals that don't support them.


### PR DESCRIPTION
> `npm-check -u` fail (support ied / pnpm) #101
> dylang/npm-check#101

this feature usage:
`npm-check -u -i pnpm` -> `$ `[pnpm](https://github.com/rstacruz/pnpm)` install`