### PR TITLE
Add `NPM_CHECK_INSTALLER` (fix #101)

### DIFF
--- a/lib/npm/spawn-npm.js
+++ b/lib/npm/spawn-npm.js
@@ -20,11 +20,12 @@ function install(packages, currentState) {
         .concat(color)
         .filter(Boolean);
 
-    const logMessage = `${chalk.green('npm')} ${chalk.green(npmArgs.join(' '))}`;
+    const installer = process.env.NPM_CHECK_INSTALLER || 'npm';
+    const logMessage = `${chalk.green(installer)} ${chalk.green(npmArgs.join(' '))}`;
     const spinner = ora(logMessage);
     spinner.start();
 
-    return execa('npm', npmArgs, {cwd: currentState.get('cwd')}).then(output => {
+    return execa(installer, npmArgs, {cwd: currentState.get('cwd')}).then(output => {
         spinner.stop();
         console.log(logMessage);
         console.log(output.stdout);

--- a/templates/readme/cli.md
+++ b/templates/readme/cli.md
@@ -1,6 +1,6 @@
 ## On the command line
 
-This is how you should use `npm-check`. 
+This is how you should use `npm-check`.
 
 ### Install
 
@@ -26,7 +26,7 @@ The result should look like the screenshot, or something nice when your packages
 ```
 Usage
   $ npm-check <path> <options>
-  
+
 Path
   Where to check. Defaults to current directory. Use -g for checking global modules.
 
@@ -83,17 +83,26 @@ By default `npm-check` will look at packages listed as `dependencies` and `devDe
 This option will let it ignore outdated and unused checks for packages listed as `devDependencies`.
 
 ##### -E, --save-exact
-  
+
 Install packages using `--save-exact`, meaning exact versions will be saved in package.json.
- 
+
 Applies to both `dependencies` and `devDependencies`.
 
 ##### --color, --no-color
-  
+
 Enable or disable color support.
 
 By default `npm-check` uses colors if they are available.
 
 ##### --emoji, --no-emoji
-  
-Enable or disable emoji support. Useful for terminals that don't support them. 
+
+Enable or disable emoji support. Useful for terminals that don't support them.
+
+##### use another npm installer
+
+if specify environment `NPM_CHECK_INSTALLER`, do the update by using the specified installer. (such as [ied](https://github.com/alexanderGugel/ied), [pnpm](https://github.com/rstacruz/pnpm))
+
+```bash
+NPM_CHECK_INSTALLER=pnpm npm-check -u
+# pnpm install --save-dev foo@version --color=always
+```


### PR DESCRIPTION
```bash
NPM_CHECK_INSTALLER=pnpm npm-check -u
# pnpm install --save-dev foo@version --color=always

NPM_CHECK_INSTALLER=ied npm-check -u
# ied install --save-dev foo@version --color=always
```
can change the installer in the environment variable. :+1: (refs https://github.com/dylang/npm-check/pull/102#discussion_r58061024)