### PR TITLE
Report dependencies being used but not in the package.json

### DIFF
--- a/lib/check-npm.js
+++ b/lib/check-npm.js
@@ -12,6 +12,7 @@ const ora = require('ora');
 
 let spinner;
 
+
 function processModule(moduleName, currentState) {
     const cwdPackageJson = currentState.get('cwdPackageJson');
 
@@ -29,17 +30,29 @@ function processModule(moduleName, currentState) {
     const packageJsonVersion = cwdPackageJson.dependencies[moduleName] ||
         cwdPackageJson.devDependencies[moduleName] ||
         currentState.get('globalPackages')[moduleName];
-    if (!semver.validRange(packageJsonVersion)) {
+
+    if (packageJsonVersion && !semver.validRange(packageJsonVersion)) {
         return false;
     }
 
     spinner.text = `Checking registry for ${moduleName}`;
 
     const unusedDependencies = currentState.get('unusedDependencies');
+    const missingFromPackageJson = currentState.get('missingFromPackageJson');
+
+    function foundIn(files) {
+        if (!files) {
+            return;
+        }
+
+        return 'Found in: ' + files.map(filepath => filepath.replace(currentState.get('cwd'), ''))
+            .join(', ')
+    }
 
     return getNpmInfo(moduleName)
         .then(fromRegistry => {
             spinner.text = `Checking registry for ${moduleName} - complete.`;
+            spinner.start();
 
             const installedVersion = modulePackageJson.version;
 
@@ -72,6 +85,9 @@ function processModule(moduleName, currentState) {
                 packageWanted: versionWanted,
                 packageJson: packageJsonVersion,
 
+                // Missing from package json
+                notInPackageJson: foundIn(missingFromPackageJson[moduleName]),
+
                 // meta
                 devDependency: _.has(cwdPackageJson.devDependencies, moduleName),
                 usedInScripts: _.findKey(cwdPackageJson.scripts, script => {
@@ -98,7 +114,7 @@ function processData(currentState) {
 
     spinner = ora(`Checking the npm registry.`);
     spinner.enabled = currentState.get('spinner');
-    spinner.start();
+
 
     function dependencies(pkg) {
         if (currentState.get('global')) {
@@ -112,7 +128,9 @@ function processData(currentState) {
         return merge(pkg.dependencies, pkg.devDependencies);
     }
 
-    const allDependencies = Object.keys(dependencies(cwdPackageJson));
+    const missingFromPackageJson = currentState.get('missingFromPackageJson') || {};
+    const allDependencies = [].concat.call(Object.keys(dependencies(cwdPackageJson)),
+        Object.keys(missingFromPackageJson));
 
     const npmPromises = allDependencies.map(moduleName => processModule(moduleName, currentState));
 
@@ -125,6 +143,9 @@ function processData(currentState) {
 
             spinner.stop();
             return currentState;
+        }).catch(err => {
+            spinner.stop();
+            throw err;
         });
 }
 

--- a/lib/check-npm.js
+++ b/lib/check-npm.js
@@ -12,7 +12,6 @@ const ora = require('ora');
 
 let spinner;
 
-
 function processModule(moduleName, currentState) {
     const cwdPackageJson = currentState.get('cwdPackageJson');
 
@@ -46,7 +45,7 @@ function processModule(moduleName, currentState) {
         }
 
         return 'Found in: ' + files.map(filepath => filepath.replace(currentState.get('cwd'), ''))
-            .join(', ')
+            .join(', ');
     }
 
     return getNpmInfo(moduleName)
@@ -114,7 +113,6 @@ function processData(currentState) {
 
     spinner = ora(`Checking the npm registry.`);
     spinner.enabled = currentState.get('spinner');
-
 
     function dependencies(pkg) {
         if (currentState.get('global')) {

--- a/lib/check-unused.js
+++ b/lib/check-unused.js
@@ -45,6 +45,7 @@ function checkUnused(currentState) {
         spinner.stop();
         const unusedDependencies = [].concat(depCheckResults.dependencies, depCheckResults.devDependencies);
         currentState.set('unusedDependencies', unusedDependencies);
+        currentState.set('missingFromPackageJson', depCheckResults.missing || {});
         return currentState;
     });
 }

--- a/lib/output.js
+++ b/lib/output.js
@@ -17,6 +17,7 @@ function render(pkg) {
     // DYLAN: clean this up
     const status = _([
         pkg.notInstalled ? chalk.bgGreen.white.bold(emoji(' :worried: ') + ' MISSING! ') + ' Not installed.' : '',
+        pkg.notInPackageJson ? chalk.bgGreen.white.bold(emoji(' :worried: ') + ' PKG ERR! ') + ' Not in the package.json. ' + pkg.notInPackageJson : '',
         pkg.pkgError && !pkg.notInstalled ? chalk.bgGreen.white.bold(emoji(' :worried: ') + ' PKG ERR! ') + ' ' + chalk.red(pkg.pkgError.message) : '',
         pkg.bump && pkg.easyUpgrade ? [
             chalk.bgGreen.white.bold(emoji(' :heart_eyes: ') + ' UPDATE!  ') + ' Your local install is out of date. ' + chalk.blue.underline(pkg.homepage || ''),

--- a/lib/update.js
+++ b/lib/update.js
@@ -69,7 +69,6 @@ function unselectable(options) {
 }
 
 function createChoices(packages, options) {
-
     const filteredChoices = _.filter(packages, options.filter);
 
     const choices = filteredChoices.map(choice)

--- a/lib/update.js
+++ b/lib/update.js
@@ -69,6 +69,7 @@ function unselectable(options) {
 }
 
 function createChoices(packages, options) {
+
     const filteredChoices = _.filter(packages, options.filter);
 
     const choices = filteredChoices.map(choice)

--- a/lib/util/state.js
+++ b/lib/util/state.js
@@ -27,7 +27,8 @@ const defaultOptions = {
     cwdPackageJson: {devDependencies: {}, dependencies: {}},
 
     packages: false,
-    unusedDependencies: false
+    unusedDependencies: false,
+    missingFromPackageJson: {}
 };
 
 function state(userOptions) {
@@ -67,7 +68,7 @@ function state(userOptions) {
         if (currentStateObject.hasOwnProperty(key)) {
             currentStateObject[key] = value;
         } else {
-            throw new Error(`unknown option "${key}" setting to "${value}".`);
+            throw new Error(`unknown option "${key}" setting to "${JSON.stringify(value, false, 4)}".`);
         }
     }
 


### PR DESCRIPTION
It will report packages being used that aren't in the `package.json` when running `npm-check`, but it won't include them when doing update because we don't run `depcheck` when doing updates to speed up updating. It seems like a minor feature that might not be worth slowing down the update feature.

Fixes #69 