### PR TITLE
avoid breaking the build when dependencies are updated.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
   - nodejs_version: 4
   - nodejs_version: 5
 
-
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install
@@ -13,10 +12,7 @@ test_script:
   - node --version
   - npm --version
   - npm run lint
-  - node lib\cli.js
-
-cache:
-  - node_modules -> package.json
+  - node lib\cli.js || Exit code: %errorlevel%
 
 build: off
 shallow_clone: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ test_script:
   - node --version
   - npm --version
   - npm run lint
-  - node lib\cli.js || Exit code: %errorlevel%
+  - "node lib\cli.js || Exit code: %errorlevel%"
 
 build: off
 shallow_clone: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,15 +5,15 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm cache clean
-  - npm install --force
+  - npm i -g npm@3
+  - npm install
   - set CI=true
 
 test_script:
   - node --version
   - npm --version
   - npm run lint
-  - "node lib\\cli.js || echo Exit code: %errorlevel%"
+  - "node lib\\cli.js || echo Exit code: %errorlevel% || ver > null"
 
 build: off
 shallow_clone: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ test_script:
   - node --version
   - npm --version
   - npm run lint
-  - "node lib\cli.js || Exit code: %errorlevel%"
+  - "node lib\\cli.js || Exit code: %errorlevel%"
 
 build: off
 shallow_clone: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,8 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install
+  - npm cache clean
+  - npm install --force
   - set CI=true
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ test_script:
   - node --version
   - npm --version
   - npm run lint
-  - "node lib\\cli.js || Exit code: %errorlevel%"
+  - "node lib\\cli.js || echo Exit code: %errorlevel%"
 
 build: off
 shallow_clone: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,8 @@ test_script:
   - node --version
   - npm --version
   - npm run lint
-  - "node lib\\cli.js || echo Exit code: %errorlevel% || ver > null"
+  - "node lib\\cli.js || ver > null"
+  - "echo Exit code: %errorlevel%"
 
 build: off
 shallow_clone: true

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -96,5 +96,5 @@ npmCheck(options)
         } else {
             console.log('For more detail, add `--debug` to the command');
         }
-        process.exit(-1);
+        process.exit(1);
     });

--- a/lib/out/static-output.js
+++ b/lib/out/static-output.js
@@ -82,7 +82,7 @@ function outputConsole(currentState) {
         console.log('');
         console.log(renderedTable);
         console.log(`Use ${chalk.green(`npm-check -${currentState.get('global') ? 'g' : ''}u`)} for interactive update.`);
-        process.exit(-1);
+        process.exit(1);
     } else {
         console.log(`${emoji(':heart:  ')}Your modules look ${chalk.bold('amazing')}. Keep up the great work.${emoji(' :heart:')}`);
         process.exit(0);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "xo",
-    "test": "xo && ./lib/cli.js",
+    "test": "xo && ./lib/cli.js || echo Exit Status: $?.",
     "repos": "grunt repos # required for grunt readme to run",
     "readme": "grunt readme"
   },


### PR DESCRIPTION
* avoid breaking the build when dependencies are updated.
* switch exit status from -1 to 1.
* drop caching on appveyor that may be causing install errors with #120 