### PR TITLE
Ignore deps

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "es2015"
   ],
-  plugins: [
+  "plugins": [
     "transform-runtime"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea/
 /node_modules/
 /*.log
+/lib-es5/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /.idea/
 /node_modules/
 /*.log
-/lib-es5/

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This option will let it ignore outdated and unused checks for packages listed as
 
 Ignore dependencies that match specified glob.
 
-`$ npm-check -i babel-*` will ignore all all dependencies starting with 'babel-'.
+`$ npm-check -i babel-*` will ignore all dependencies starting with 'babel-'.
 
 #### `-E, --save-exact`
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Options
   -g, --global          Look at global modules.
   -s, --skip-unused     Skip check for unused packages.
   -p, --production      Skip devDependencies.
+  -i, --ignore          Ignore dependencies based on succeeding glob.
   -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
   --no-color            Force or disable color output.
   --no-emoji            Remove emoji support. No emoji in default in CI environments.
@@ -133,6 +134,12 @@ This is enabled by default when using `global` or `update`.
 By default `npm-check` will look at packages listed as `dependencies` and `devDependencies`.
 
 This option will let it ignore outdated and unused checks for packages listed as `devDependencies`.
+
+#### `-i, --ignore`
+
+Ignore dependencies that match specified glob.
+
+`$ npm-check -i babel-*` will ignore all all dependencies starting with 'babel-'.
 
 #### `-E, --save-exact`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -42,7 +42,8 @@ const cli = meow({
             g: 'global',
             s: 'skip-unused',
             p: 'production',
-            E: 'save-exact'
+            E: 'save-exact',
+            i: 'ignore'
         },
         default: {
             dir: process.cwd(),
@@ -58,6 +59,9 @@ const cli = meow({
             'color',
             'emoji',
             'spinner'
+        ],
+        string: [
+            'ignore'
         ]
     });
 
@@ -71,7 +75,8 @@ const options = {
     emoji: cli.flags.emoji,
     installer: process.env.NPM_CHECK_INSTALLER || 'npm',
     debug: cli.flags.debug,
-    spinner: cli.flags.spinner
+    spinner: cli.flags.spinner,
+    ignore: cli.flags.ignore
 };
 
 if (options.debug) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -26,6 +26,7 @@ const cli = meow({
           -g, --global          Look at global modules.
           -s, --skip-unused     Skip check for unused packages.
           -p, --production      Skip devDependencies.
+          -i, --ignore          Ignore dependencies based on succeeding glob.
           -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
           --no-color            Force or disable color output.
           --no-emoji            Remove emoji support. No emoji in default in CI environments.

--- a/lib/in/create-package-summary.js
+++ b/lib/in/create-package-summary.js
@@ -7,6 +7,7 @@ const semverDiff = require('semver-diff');
 const pathExists = require('path-exists');
 const path = require('path');
 const semver = require('semver');
+const minimatch = require('minimatch');
 
 function createPackageSummary(moduleName, currentState) {
     const cwdPackageJson = currentState.get('cwdPackageJson');
@@ -28,6 +29,15 @@ function createPackageSummary(moduleName, currentState) {
 
     if (packageJsonVersion && !semver.validRange(packageJsonVersion)) {
         return false;
+    }
+
+    // Ignore specified '--ignore' package globs
+    const ignore = currentState.get('ignore');
+    if (ignore) {
+        const ignoreMatch = Array.isArray(ignore) ? ignore.some(ignoredModule => minimatch(moduleName, ignoredModule)) : minimatch(moduleName, ignore);
+        if (ignoreMatch) {
+            return false;
+        }
     }
 
     const unusedDependencies = currentState.get('unusedDependencies');

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -17,6 +17,7 @@ const defaultOptions = {
     emoji: true,
     spinner: false,
     installer: 'npm',
+    ignore: [],
 
     globalPackages: {},
     cwdPackageJson: {devDependencies: {}, dependencies: {}},

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "lodash": "^4.7.0",
     "meow": "^3.7.0",
     "merge-options": "0.0.64",
-    "minimatch": "^3.0.0",
+    "minimatch": "^3.0.2",
     "node-emoji": "^1.0.3",
     "ora": "^0.2.1",
     "package-json": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "lodash": "^4.7.0",
     "meow": "^3.7.0",
     "merge-options": "0.0.64",
+    "minimatch": "^3.0.0",
     "node-emoji": "^1.0.3",
     "ora": "^0.2.1",
     "package-json": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "xo ./lib/*.js",
     "test": "xo ./lib/*.js && ./bin/cli.js || echo Exit Status: $?.",
     "transpile": "babel lib --out-dir lib-es5",
+    "watch": "babel lib --out-dir lib-es5 --watch",
     "prepublish": "npm run transpile",
     "repos": "grunt repos # required for grunt readme to run",
     "readme": "grunt readme"

--- a/templates/readme/cli.md
+++ b/templates/readme/cli.md
@@ -100,7 +100,7 @@ This option will let it ignore outdated and unused checks for packages listed as
 
 Ignore dependencies that match specified glob.
 
-`$ npm-check -i babel-*` will ignore all all dependencies starting with 'babel-'.
+`$ npm-check -i babel-*` will ignore all dependencies starting with 'babel-'.
 
 ### `-E, --save-exact`
 

--- a/templates/readme/cli.md
+++ b/templates/readme/cli.md
@@ -34,6 +34,7 @@ Options
   -g, --global          Look at global modules.
   -s, --skip-unused     Skip check for unused packages.
   -p, --production      Skip devDependencies.
+  -i, --ignore          Ignore dependencies based on succeeding glob.
   -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
   --no-color            Force or disable color output.
   --no-emoji            Remove emoji support. No emoji in default in CI environments.
@@ -95,6 +96,12 @@ By default `npm-check` will look at packages listed as `dependencies` and `devDe
 
 This option will let it ignore outdated and unused checks for packages listed as `devDependencies`.
 
+#### `-i, --ignore`
+
+Ignore dependencies that match specified glob.
+
+`$ npm-check -i babel-*` will ignore all all dependencies starting with 'babel-'.
+
 ### `-E, --save-exact`
 
 Install packages using `--save-exact`, meaning exact versions will be saved in package.json.
@@ -114,4 +121,3 @@ Enable or disable emoji support. Useful for terminals that don't support them. A
 ### `--spinner, --no-spinner`
 
 Enable or disable the spinner. Useful for terminals that don't support them. Automatically disabled in CI servers.
-


### PR DESCRIPTION
Ignore dependencies by specifying a glob, as outlined in Issue #71.

`$ npm-check --ignore babel-* --ignore chalk` will ignore all dependencies starting with 'babel-' and named 'chalk'.

Used Minimatch instead of globby for String matching instead of relative (cwd) file matching.

Didn't update API section of README.md

![output5](https://cloud.githubusercontent.com/assets/11944012/14865879/dc034fa8-0c8e-11e6-9fda-7973c5808243.gif)
