### PR TITLE
Suggest the correct update command in global mode

### DIFF
--- a/lib/out/static-output.js
+++ b/lib/out/static-output.js
@@ -9,11 +9,14 @@ function uppercaseFirstLetter(str) {
     return str[0].toUpperCase() + str.substr(1);
 }
 
-function render(pkg) {
+function render(pkg, currentState) {
     const packageName = pkg.moduleName;
     const rows = [];
 
     const indent = '           ' + emoji('   ');
+    const flags = currentState.get('global') ? '--global' : `--save${pkg.devDependency ? '-dev' : ''}`;
+    const upgradeCommand = `npm install ${flags} ${packageName}@${pkg.latest}`;
+    const upgradeMessage = `${chalk.green(upgradeCommand)} to go from ${pkg.installed} to ${pkg.latest}`;
     // DYLAN: clean this up
     const status = _([
         pkg.notInstalled ? chalk.bgRed.white.bold(emoji(' :worried: ') + ' MISSING! ') + ' Not installed.' : '',
@@ -21,11 +24,11 @@ function render(pkg) {
         pkg.pkgError && !pkg.notInstalled ? chalk.bgGreen.white.bold(emoji(' :worried: ') + ' PKG ERR! ') + ' ' + chalk.red(pkg.pkgError.message) : '',
         pkg.bump && pkg.easyUpgrade ? [
             chalk.bgGreen.white.bold(emoji(' :heart_eyes: ') + ' UPDATE!  ') + ' Your local install is out of date. ' + chalk.blue.underline(pkg.homepage || ''),
-            indent + chalk.green('npm install --save' + (pkg.devDependency ? '-dev' : '') + ' ' + packageName + '@' + pkg.latest) + ' to go from ' + pkg.installed + ' to ' + pkg.latest
+            indent + upgradeMessage
         ] : '',
         pkg.bump && !pkg.easyUpgrade ? [
             chalk.white.bold.bgGreen((pkg.bump === 'nonSemver' ? emoji(' :sunglasses: ') + ' new ver! '.toUpperCase() : emoji(' :sunglasses: ') + ' ' + pkg.bump.toUpperCase() + ' UP ')) + ' ' + uppercaseFirstLetter(pkg.bump) + ' update available. ' + chalk.blue.underline(pkg.homepage || ''),
-            indent + chalk.green('npm install --save' + (pkg.devDependency ? '-dev' : '') + ' ' + packageName + '@' + pkg.latest) + ' to go from ' + pkg.installed + ' to ' + pkg.latest
+            indent + upgradeMessage
         ] : '',
         pkg.unused ? [
             chalk.black.bold.bgWhite(emoji(' :confused: ') + ' NOTUSED? ') + ` ${chalk.yellow(`Still using ${packageName}?`)}`,


### PR DESCRIPTION
Updating global packages requires running `npm install --global` rather than `npm install --save[-dev]`.