### PR TITLE
Automatically find project root as cwd

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -10,6 +10,7 @@ const npmCheck = require('./index');
 const staticOutput = require('./out/static-output');
 const interactiveUpdate = require('./out/interactive-update');
 const debug = require('./state/debug');
+const pkgDir = require('pkg-dir');
 
 updateNotifier({pkg}).notify();
 
@@ -45,7 +46,7 @@ const cli = meow({
             E: 'save-exact'
         },
         default: {
-            dir: process.cwd(),
+            dir: pkgDir.sync() || process.cwd(),
             emoji: !isCI,
             spinner: !isCI
         },

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "ora": "^0.2.1",
     "package-json": "^2.0.1",
     "path-exists": "^2.1.0",
+    "pkg-dir": "^1.0.0",
     "semver": "^5.0.1",
     "semver-diff": "^2.0.0",
     "text-table": "^0.2.0",


### PR DESCRIPTION
Currently running `npm-check -u` anywhere but in a project root will cause it to fail.

This PR will make npm-check automatically detect the project root and start looking for packages there.

Related: gulp and grunt behave the same