### PR TITLE
Add Promise polyfill to allow running on node 0.10.x

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+require('es6-promise').polyfill();
 const meow = require('meow');
 const updateNotifier = require('update-notifier');
 const isCI = require('is-ci');

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "chalk": "^1.1.3",
     "co": "^4.6.0",
     "depcheck": "^0.6.3",
+    "es6-promise": "^3.2.1",
     "execa": "^0.2.2",
     "giturl": "^1.0.0",
     "global-modules": "^0.2.0",


### PR DESCRIPTION
With this small change, npm-check will work with node 0.10.x.