### PR TITLE
Add eslint-plugin-* and @types/* to ignore matches list for unused

### DIFF
--- a/lib/in/get-unused-packages.js
+++ b/lib/in/get-unused-packages.js
@@ -38,6 +38,8 @@ function checkUnused(currentState) {
                 'angular-*',
                 'babel-*',
                 'metalsmith-*',
+                'eslint-plugin-*',
+                '@types/*',
                 'grunt',
                 'mocha',
                 'ava'


### PR DESCRIPTION
removes false positives for eslint plugins and typescript types