### PR TITLE
Ignore matches add support for scoped repos and remove eslint-plugin

### DIFF
--- a/lib/in/get-unused-packages.js
+++ b/lib/in/get-unused-packages.js
@@ -46,6 +46,13 @@ function checkUnused(currentState) {
             ]
         };
 
+        const ignoreMatchesScoped = _.map(depCheckOptions.ignoreMatches, (ignoreMatch) => {
+            if (_.includes(ignoreMatch, "@")) return ignoreMatch;
+
+            return `@*/${ignoreMatch}`;
+        });
+        depCheckOptions.ignoreMatches = depCheckOptions.ignoreMatches.concat(ignoreMatchesScoped);
+
         depcheck(currentState.get('cwd'), depCheckOptions, resolve);
     }).then(depCheckResults => {
         spinner.stop();
@@ -56,7 +63,7 @@ function checkUnused(currentState) {
 
         // currently missing will return devDependencies that aren't really missing
         const missingFromPackageJson = _.omit(depCheckResults.missing || {},
-                    Object.keys(cwdPackageJson.dependencies), Object.keys(cwdPackageJson.devDependencies));
+            Object.keys(cwdPackageJson.dependencies), Object.keys(cwdPackageJson.devDependencies));
         currentState.set('missingFromPackageJson', missingFromPackageJson);
         return currentState;
     });

--- a/lib/in/get-unused-packages.js
+++ b/lib/in/get-unused-packages.js
@@ -38,7 +38,6 @@ function checkUnused(currentState) {
                 'angular-*',
                 'babel-*',
                 'metalsmith-*',
-                'eslint-plugin-*',
                 '@types/*',
                 'grunt',
                 'mocha',


### PR DESCRIPTION
Add support for also ignoring matches that are scoped repositories and rolls back adding eslint-plugin in my previous PR as this was actually caused by an issue in dep-check with handling scoped eslint-plugins. I will fix there.