### PR TITLE
Add TypeScript typedefs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,50 @@
+declare module NpmCheck { 
+  interface INpmCheckOptions {
+    global?: boolean;
+    update?: boolean;
+    skipUnused?: boolean;
+    ignoreDev?: boolean;
+    cwd?: string;
+    saveExact?: boolean;
+    currentState?: Object;
+  }
+
+  type INpmCheckGetSetValues = "packages" | "debug" | "global" | "cwd" | "cwdPackageJson" | "emoji";
+
+  type INpmVersionBumpType = "patch" | "minor" | "major" | "prerelease" | "build" | "nonSemver" | null;
+
+  interface INpmCheckCurrentState {
+    get: (key: INpmCheckGetSetValues) => INpmCheckPackage[];
+    set: (key: INpmCheckGetSetValues, val: any) => void;
+  }
+
+  interface INpmCheckPackage {
+    moduleName: string;                  // name of the module. 
+    homepage: string;                    // url to the home page. 
+    regError: any;                       // error communicating with the registry 
+    pkgError: any;                       // error reading the package.json 
+    latest: string;                      // latest according to the registry. 
+    installed: string;                   // version installed 
+    isInstalled: boolean;                // Is it installed? 
+    notInstalled: boolean;               // Is it installed? 
+    packageWanted: string;               // Requested version from the package.json. 
+    packageJson: string;                 // Version or range requested in the parent package.json. 
+    devDependency: boolean;              // Is this a devDependency? 
+    usedInScripts: undefined | string[], // Array of `scripts` in package.json that use this module. 
+    mismatch: boolean;                   // Does the version installed not match the range in package.json? 
+    semverValid: string;                 // Is the installed version valid semver? 
+    easyUpgrade: boolean;                // Will running just `npm install` upgrade the module? 
+    bump: INpmVersionBumpType;           // What kind of bump is required to get the latest 
+    unused: boolean;                     // Is this module used in the code? 
+  }
+
+  //The default function returns a promise
+  export default function(options: INpmCheckOptions): {
+    then(stateFn: (state: INpmCheckCurrentState) => void): void;
+  };
+  
+}
+
+declare module "npm-check" {
+    export = NpmCheck.default;
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "engines": {
     "node": ">=0.11.0"
   },
+  "types": "./index.d.ts",
+  "typings": "./index.d.ts",
   "scripts": {
     "lint": "xo ./lib/*.js",
     "test": "npm run lint && ./bin/cli.js || echo Exit Status: $?.",


### PR DESCRIPTION
I've written some TypeScript type definitions for this project, and this PR will include them in the distribution and allow either [typings](https://github.com/typings/typings) or @types in TypeScript 2.x to automatically pick them up.

More info: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html