### PR TITLE
add option to include special files in the check for unused dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Options
   -d, --dev-only        Look at devDependencies only (skip dependencies).
   -i, --ignore          Ignore dependencies based on succeeding glob.
   -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
+  --specials            List of depcheck specials to include in check for unused dependencies.
   --no-color            Force or disable color output.
   --no-emoji            Remove emoji support. No emoji in default in CI environments.
   --debug               Debug output. Throw in a gist when creating issues on github.
@@ -142,6 +143,14 @@ Install packages using `--save-exact`, meaning exact versions will be saved in p
 
 Applies to both `dependencies` and `devDependencies`.
 
+#### `--specials`
+
+Check special (e.g. config) files when looking for unused dependencies.
+
+`$ npm-check --specials=bin,webpack` will look in the `scripts` section of package.json and in webpack config.
+
+See [https://github.com/depcheck/depcheck#special](https://github.com/depcheck/depcheck#special) for more information.
+
 #### `--color, --no-color`
 
 Enable or disable color support.
@@ -207,6 +216,10 @@ npmCheck(options)
 * Update package.json with exact version `x.y.z`  instead of semver range `^x.y.z`.
 * default is `false`
 
+#### `specials`
+
+* List of [`depcheck`](https://github.com/depcheck/depcheck) special parsers to include.
+* default is `''`
 
 #### `currentState`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -29,6 +29,7 @@ const cli = meow({
           -p, --production      Skip devDependencies.
           -i, --ignore          Ignore dependencies based on succeeding glob.
           -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
+          --specials            List of depcheck specials to include in check for unused dependencies.
           --no-color            Force or disable color output.
           --no-emoji            Remove emoji support. No emoji in default in CI environments.
           --debug               Debug output. Throw in a gist when creating issues on github.
@@ -64,7 +65,8 @@ const cli = meow({
             'spinner'
         ],
         string: [
-            'ignore'
+            'ignore',
+            'specials'
         ]
     });
 
@@ -76,6 +78,7 @@ const options = {
     ignoreDev: cli.flags.production,
     devOnly: cli.flags.devOnly,
     saveExact: cli.flags.saveExact,
+    specials: cli.flags.specials,
     emoji: cli.flags.emoji,
     installer: process.env.NPM_CHECK_INSTALLER || 'npm',
     debug: cli.flags.debug,

--- a/lib/in/get-unused-packages.js
+++ b/lib/in/get-unused-packages.js
@@ -46,6 +46,12 @@ function checkUnused(currentState) {
             ]
         };
 
+        const specialFiles = currentState.get('specials');
+        if (specialFiles && specialFiles.indexOf(',') > 0) {
+            depCheckOptions.specials = specialFiles.split(',')
+                .map((special) => depcheck.special[special]);
+        }
+
         depcheck(currentState.get('cwd'), depCheckOptions, resolve);
     }).then(depCheckResults => {
         spinner.stop();

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -14,6 +14,7 @@ const defaultOptions = {
     devOnly: false,
     forceColor: false,
     saveExact: false,
+    specials: '',
     debug: false,
     emoji: true,
     spinner: false,


### PR DESCRIPTION
Example:

```sh
$ npm-check --specials=eslint,webpack
```

`depcheck` supports the concept of `specials` which are special parsers to check files other than your usual JavaScript source code. (See https://github.com/depcheck/depcheck#special.)

Current support includes npm scripts, eslint, webpack, babel and mocha. (See https://github.com/depcheck/depcheck/tree/master/src/special for the full list.)

This PR adds `specials` to the API and CLI and passes the value through to `depcheck` when checking for unused dependencies.

I've opened a PR in `depcheck` - https://github.com/depcheck/depcheck/pull/206 - to make the list of available options clearer in the documentation.