### PR TITLE
Fix skip unused

### DIFF
--- a/lib/in/get-unused-packages.js
+++ b/lib/in/get-unused-packages.js
@@ -22,8 +22,6 @@ function checkUnused(currentState) {
             return;
         }
 
-        console.log('!!! unused !!!');
-
         const depCheckOptions = {
             ignoreDirs: [
                 'sandbox',

--- a/lib/in/get-unused-packages.js
+++ b/lib/in/get-unused-packages.js
@@ -19,7 +19,10 @@ function checkUnused(currentState) {
     return new Promise(resolve => {
         if (skipUnused(currentState)) {
             resolve(currentState);
+            return;
         }
+
+        console.log('!!! unused !!!');
 
         const depCheckOptions = {
             ignoreDirs: [


### PR DESCRIPTION
As mentioned in #175, the skip-unused option only prevents unused warnings from being shown in the console.  The processing for this option could be quite significant. This PR skips the processing for the unused check when the user has indicated they do not want that information.