### PR TITLE
Check special files even when only one is provided

### DIFF
--- a/lib/in/get-unused-packages.js
+++ b/lib/in/get-unused-packages.js
@@ -11,6 +11,15 @@ function skipUnused(currentState) {
         !currentState.get('cwdPackageJson').name;   // there's no package.json
 }
 
+function getSpecialParsers(currentState) {
+    const specialsInput = currentState.get('specials');
+    if (!specialsInput) return;
+    return specialsInput
+        .split(',')
+        .map((special) => depcheck.special[special])
+        .filter(Boolean);
+}
+
 function checkUnused(currentState) {
     const spinner = ora(`Checking for unused packages. --skip-unused if you don't want this.`);
     spinner.enabled = spinner.enabled && currentState.get('spinner');
@@ -44,14 +53,9 @@ function checkUnused(currentState) {
                 'grunt',
                 'mocha',
                 'ava'
-            ]
+            ],
+            specials: getSpecialParsers(currentState)
         };
-
-        const specialFiles = currentState.get('specials');
-        if (specialFiles && specialFiles.indexOf(',') > 0) {
-            depCheckOptions.specials = specialFiles.split(',')
-                .map((special) => depcheck.special[special]);
-        }
 
         depcheck(currentState.get('cwd'), depCheckOptions, resolve);
     }).then(depCheckResults => {


### PR DESCRIPTION
@amilajack I noticed a bug in the code you merged yesterday. Sorry about that! 🙈

It worked fine with multiple special files,

e.g. `npm-check --specials eslint,webpack`

but would ignore the option when only one was provided:

e.g. `npm-check --specials eslint`

This PR fixes the issue and cleans up the code a bit.