### PR TITLE
getting all metadata from package-json module so the homepage can be …

### DIFF
--- a/lib/in/get-latest-from-registry.js
+++ b/lib/in/get-latest-from-registry.js
@@ -8,7 +8,7 @@ const cpuCount = require('os').cpus().length;
 const throat = require('throat')(cpuCount);
 
 function getNpmInfo(packageName) {
-    return throat(() => packageJson(packageName, { allVersions: true }))
+    return throat(() => packageJson(packageName, { fullMetadata: true, allVersions: true }))
         .then(rawData => {
             const CRAZY_HIGH_SEMVER = '8000.0.0';
 


### PR DESCRIPTION
…extrapolated

A breaking change was introduced into package-json [v4](https://github.com/sindresorhus/package-json/commit/282119311c97b5e7ebd9f61372635f61cfb5fce3) that wasn't taken into consideration here, and this flag will put back the behavior like it used to be.

This address this issue https://github.com/dylang/npm-check/issues/234