### PR TITLE
Fixed README.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ npmCheck(options)
 
 #### `currentState`
 
-The result of the promise is a `currentState` object, look in [state.js](https://github.com/dylang/npm-check/blob/master/lib/util/state.js) to see how it works.
+The result of the promise is a `currentState` object, look in [state.js](lib/state/state.js) to see how it works.
 
 You will probably want `currentState.get('packages')` to get an array of packages and the state of each of them.
 


### PR DESCRIPTION
Fixed link and used relative instead of absolute path. This should probably be done for all links...