### PR TITLE
add update-all flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Path
 
 Options
   -u, --update          Interactive update.
+  -y, --udpate-all      Uninteractive update. Apply all updates without prompting.
   -g, --global          Look at global modules.
   -s, --skip-unused     Skip check for unused packages.
   -p, --production      Skip devDependencies.
@@ -103,6 +104,10 @@ You can also use this for dry-run testing:
 ```bash
 NPM_CHECK_INSTALLER=echo npm-check -u
 ```
+
+#### `-y, --update-all`
+
+Updates your dependencies like `--update`, just without any prompt. This is especially useful if you want to automate your dependency updates with `npm-check`.
 
 #### `-g, --global`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,6 +9,7 @@ const pkg = require('../package.json');
 const npmCheck = require('./index');
 const staticOutput = require('./out/static-output');
 const interactiveUpdate = require('./out/interactive-update');
+const updateAll = require('./out/update-all');
 const debug = require('./state/debug');
 const pkgDir = require('pkg-dir');
 
@@ -24,6 +25,7 @@ const cli = meow({
 
         Options
           -u, --update          Interactive update.
+          -y, --udpate-all      Uninteractive update. Apply all updates without prompting.
           -g, --global          Look at global modules.
           -s, --skip-unused     Skip check for unused packages.
           -p, --production      Skip devDependencies.
@@ -43,6 +45,7 @@ const cli = meow({
     {
         alias: {
             u: 'update',
+            y: 'update-all',
             g: 'global',
             s: 'skip-unused',
             p: 'production',
@@ -57,6 +60,7 @@ const cli = meow({
         },
         boolean: [
             'update',
+            'update-all',
             'global',
             'skip-unused',
             'production',
@@ -75,6 +79,7 @@ const cli = meow({
 const options = {
     cwd: cli.input[0] || cli.flags.dir,
     update: cli.flags.update,
+    updateAll: cli.flags.updateAll,
     global: cli.flags.global,
     skipUnused: cli.flags.skipUnused,
     ignoreDev: cli.flags.production,
@@ -97,6 +102,9 @@ npmCheck(options)
     .then(currentState => {
         currentState.inspectIfDebugMode();
 
+        if (options.updateAll) {
+            return updateAll(currentState);
+        }
         if (options.update) {
             return interactiveUpdate(currentState);
         }

--- a/lib/out/update-all.js
+++ b/lib/out/update-all.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const _ = require('lodash');
+const inquirer = require('inquirer');
+const chalk = require('chalk');
+const table = require('text-table');
+const installPackages = require('./install-packages');
+const emoji = require('./emoji');
+
+function updateAll(currentState) {
+    const packages = currentState.get('packages');
+
+    if (currentState.get('debug')) {
+        console.log('packages', packages);
+    }
+
+    const packagesToUpdate = packages.filter(packageEntry => packageEntry.mismatch || packageEntry.notInstalled || packageEntry.bump );
+
+    if (!packagesToUpdate.length) {
+        console.log(`${emoji(':heart:  ')}Your modules look ${chalk.bold('amazing')}. Keep up the great work.${emoji(' :heart:')}`);
+        return;
+    }
+
+    const saveDependencies = packagesToUpdate
+        .filter(pkg => !pkg.devDependency)
+        .map(pkg => pkg.moduleName + '@' + pkg.latest);
+
+    const saveDevDependencies = packagesToUpdate
+        .filter(pkg => pkg.devDependency)
+        .map(pkg => pkg.moduleName + '@' + pkg.latest);
+
+    const updatedPackages = packagesToUpdate
+        .map(pkg => pkg.moduleName + '@' + pkg.latest).join(', ');
+
+    if (!currentState.get('global')) {
+        if (saveDependencies.length) {
+            saveDependencies.unshift('--save');
+        }
+
+        if (saveDevDependencies.length) {
+            saveDevDependencies.unshift('--save-dev');
+        }
+    }
+
+    return installPackages(saveDependencies, currentState)
+        .then(currentState => installPackages(saveDevDependencies, currentState))
+        .then(currentState => {
+            console.log('');
+            console.log(chalk.green(`[npm-check] Update complete!`));
+            console.log(chalk.green('[npm-check] ' + updatedPackages));
+            console.log(chalk.green(`[npm-check] You should re-run your tests to make sure everything works with the updates.`));
+            return currentState;
+        });
+}
+
+module.exports = updateAll;

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -5,6 +5,7 @@ const debug = require('./debug');
 
 const defaultOptions = {
     update: false,
+    updateAll: false,
     global: false,
     cwd: process.cwd(),
     nodeModulesPath: false,


### PR DESCRIPTION
As mentioned in issues #279 and #214 this pull request adds an `update-all` flag which updates all dependencies without prompting. This is especially useful when someone wants to use npm-check to automate dependency updates.