### PR TITLE
README.md: Correct typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Path
 
 Options
   -u, --update          Interactive update.
-  -y, --udpate-all      Uninteractive update. Apply all updates without prompting.
+  -y, --update-all      Uninteractive update. Apply all updates without prompting.
   -g, --global          Look at global modules.
   -s, --skip-unused     Skip check for unused packages.
   -p, --production      Skip devDependencies.


### PR DESCRIPTION
This typo also appears in `npm-check --help`, but it appears to be corrected in `master`?