### PR TITLE
Switch out merge-options for xtend

### DIFF
--- a/lib/in/index.js
+++ b/lib/in/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const co = require('co');
-const merge = require('merge-options');
+const extend = require('xtend');
 const ora = require('ora');
 const getUnusedPackages = require('./get-unused-packages');
 const createPackageSummary = require('./create-package-summary');
@@ -28,11 +28,11 @@ module.exports = function (currentState) {
                 return pkg.devDependencies;
             }
 
-            return merge(pkg.dependencies, pkg.devDependencies);
+            return extend(pkg.dependencies, pkg.devDependencies);
         }
 
         const allDependencies = dependencies(cwdPackageJson);
-        const allDependenciesIncludingMissing = Object.keys(merge(allDependencies, currentState.get('missingFromPackageJson')));
+        const allDependenciesIncludingMissing = Object.keys(extend(allDependencies, currentState.get('missingFromPackageJson')));
 
         const arrayOfPackageInfo = yield allDependenciesIncludingMissing
             .map(moduleName => createPackageSummary(moduleName, currentState))

--- a/lib/in/read-package-json.js
+++ b/lib/in/read-package-json.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const merge = require('merge-options');
+const extend = require('xtend');
 
 function readPackageJson(filename) {
     let pkg;
@@ -14,7 +14,7 @@ function readPackageJson(filename) {
             error = new Error(`A package.json was found at ${filename}, but it is not valid.`);
         }
     }
-    return merge(pkg, {devDependencies: {}, dependencies: {}, error: error});
+    return extend({devDependencies: {}, dependencies: {}, error: error}, pkg)
 }
 
 module.exports = readPackageJson;

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -1,5 +1,5 @@
 'use strict';
-const mergeOptions = require('merge-options');
+const extend = require('xtend');
 const init = require('./init');
 const debug = require('./debug');
 
@@ -30,7 +30,7 @@ const defaultOptions = {
 };
 
 function state(userOptions) {
-    const currentStateObject = mergeOptions(defaultOptions, {});
+    const currentStateObject = extend(defaultOptions);
 
     function get(key) {
         if (!currentStateObject.hasOwnProperty(key)) {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "is-ci": "^1.0.8",
     "lodash": "^4.7.0",
     "meow": "^3.7.0",
-    "merge-options": "0.0.64",
     "minimatch": "^3.0.2",
     "node-emoji": "^1.0.3",
     "ora": "^0.2.1",
@@ -89,7 +88,8 @@
     "semver-diff": "^2.0.0",
     "text-table": "^0.2.0",
     "throat": "^2.0.2",
-    "update-notifier": "^2.1.0"
+    "update-notifier": "^2.1.0",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,6 +1200,12 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -1407,21 +1413,23 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global-modules@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d"
+global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
   dependencies:
-    global-prefix "^0.1.4"
-    is-windows "^0.2.0"
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
 
-global-prefix@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
   dependencies:
-    homedir-polyfill "^1.0.0"
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
     ini "^1.3.4"
-    is-windows "^0.2.0"
-    which "^1.2.12"
+    is-windows "^1.0.1"
+    which "^1.2.14"
 
 globals@^9.0.0, globals@^9.2.0:
   version "9.17.0"
@@ -1546,7 +1554,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-homedir-polyfill@^1.0.0:
+homedir-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   dependencies:
@@ -1750,7 +1758,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
+is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
@@ -1799,9 +1807,9 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-windows@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
+is-windows@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -1994,12 +2002,6 @@ meow@^3.4.2, meow@^3.7.0:
     read-pkg-up "^1.0.1"
     redent "^1.0.0"
     trim-newlines "^1.0.0"
-
-merge-options@0.0.64:
-  version "0.0.64"
-  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-0.0.64.tgz#cbe04f594a6985eaf27f7f8f0b2a3acf6f9d562d"
-  dependencies:
-    is-plain-obj "^1.1.0"
 
 micromatch@^2.1.5:
   version "2.3.11"
@@ -2551,6 +2553,13 @@ resolve-cwd@^1.0.0:
   dependencies:
     resolve-from "^2.0.0"
 
+resolve-dir@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -2951,7 +2960,13 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.2.12, which@^1.2.8:
+which@^1.2.14:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.2.8:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
@@ -3075,7 +3090,7 @@ xo@^0.13.0:
     update-notifier "^0.6.0"
     xo-init "^0.3.0"
 
-xtend@^4.0.0:
+xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
The reasons for switching are 1) the non-vulnerable `merge-options` doesn't support Node.js 0.12 which we do, and 2) it seems more stable and has a ton more downloads on npm...

Fixes #288 