### PR TITLE
feat: use pnpm on projects that previously used pnpm

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,6 +12,7 @@ const interactiveUpdate = require('./out/interactive-update');
 const updateAll = require('./out/update-all');
 const debug = require('./state/debug');
 const pkgDir = require('pkg-dir');
+const detectPreferredPM = require('preferred-pm');
 
 updateNotifier({pkg}).notify();
 
@@ -87,7 +88,7 @@ const options = {
     saveExact: cli.flags.saveExact,
     specials: cli.flags.specials,
     emoji: cli.flags.emoji,
-    installer: process.env.NPM_CHECK_INSTALLER || 'npm',
+    installer: process.env.NPM_CHECK_INSTALLER || 'auto',
     debug: cli.flags.debug,
     spinner: cli.flags.spinner,
     ignore: cli.flags.ignore
@@ -98,7 +99,16 @@ if (options.debug) {
     debug('cli.input', cli.input);
 }
 
-npmCheck(options)
+Promise.resolve()
+    .then(() => {
+        return options.installer === 'auto' ?
+            detectPreferredInstaller(options.cwd) :
+            options.installer;
+    })
+    .then(installer => {
+        options.installer = installer;
+        return npmCheck(options);
+    })
     .then(currentState => {
         currentState.inspectIfDebugMode();
 
@@ -120,3 +130,13 @@ npmCheck(options)
         }
         process.exit(1);
     });
+
+var SUPPORTED_INSTALLERS = ['npm', 'pnpm', 'ied'];
+
+function detectPreferredInstaller(cwd) {
+    return detectPreferredPM(cwd)
+        .then(preferredPM => {
+            return preferredPM && SUPPORTED_INSTALLERS.indexOf(preferredPM.name) !== -1 ?
+                preferredPM.name : 'npm';
+        });
+}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "package-json": "^4.0.1",
     "path-exists": "^2.1.0",
     "pkg-dir": "^1.0.0",
+    "preferred-pm": "^1.0.1",
     "semver": "^5.0.1",
     "semver-diff": "^2.0.0",
     "text-table": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,6 +1133,10 @@ esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
 esrecurse@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.1.0.tgz#4713b6536adf7f2ac4f327d559e7756bff648220"
@@ -1493,7 +1497,7 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.5:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1850,6 +1854,13 @@ js-yaml@^3.4.2, js-yaml@^3.5.1:
     argparse "^1.0.7"
     esprima "^3.1.1"
 
+js-yaml@^3.6.1:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -1941,6 +1952,15 @@ load-json-file@^1.0.0, load-json-file@^1.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
+
+load-yaml-file@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/load-yaml-file/-/load-yaml-file-0.1.0.tgz#f680066e691b3eeb45017672e4a3956af5b83b89"
+  dependencies:
+    graceful-fs "^4.1.5"
+    js-yaml "^3.6.1"
+    pify "^2.3.0"
+    strip-bom "^3.0.0"
 
 lodash.assign@^4.0.0:
   version "4.2.0"
@@ -2258,6 +2278,10 @@ path-exists@^2.0.0, path-exists@^2.1.0:
   dependencies:
     pinkie-promise "^2.0.0"
 
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -2314,6 +2338,13 @@ pkg-dir@^1.0.0:
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+
+preferred-pm@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/preferred-pm/-/preferred-pm-1.0.1.tgz#539df37ce944b1b765ae944a8ba34a7e68694e8d"
+  dependencies:
+    path-exists "^3.0.0"
+    which-pm "^1.0.1"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -2733,6 +2764,10 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -2959,6 +2994,13 @@ walkdir@0.0.11:
 which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+
+which-pm@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/which-pm/-/which-pm-1.0.1.tgz#c9522eb3501377413e9a8c552bbe2350c36eccc0"
+  dependencies:
+    load-yaml-file "^0.1.0"
+    path-exists "^3.0.0"
 
 which@^1.2.14:
   version "1.3.0"


### PR DESCRIPTION
If a project has a pnpm lockfile or it has a node_modules created
by pnpm then pnpm is used to update dependencies

close #291