### PR TITLE
When process.env.NODE_PATH is set, npm-check -g still goes in…

### DIFF
--- a/lib/state/init.js
+++ b/lib/state/init.js
@@ -30,7 +30,7 @@ function init(currentState, userOptions) {
 
             console.log(chalk.green('The global path you are searching is: ' + modulesPath));
 
-            currentState.set('cwd', globalModulesPath);
+            currentState.set('cwd', modulesPath);
             currentState.set('globalPackages', globalPackages(modulesPath));
         } else {
             const cwd = path.resolve(currentState.get('cwd'));


### PR DESCRIPTION
bugfix: When process.env.NODE_PATH is set, npm-check -g still goes into globalModulesPath instead of NODE_PATH