### PR TITLE
Adding filter command-line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Options
   -p, --production      Skip devDependencies.
   -d, --dev-only        Look at devDependencies only (skip dependencies).
   -i, --ignore          Ignore dependencies based on succeeding glob.
+  -f, --filter          Filter dependencies based on glob.
   -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
   --specials            List of depcheck specials to include in check for unused dependencies.
   --no-color            Force or disable color output.
@@ -143,6 +144,12 @@ This option will let it ignore outdated and unused checks for packages listed as
 Ignore dependencies that match specified glob.
 
 `$ npm-check -i babel-*` will ignore all dependencies starting with 'babel-'.
+
+#### `-f, --filter`
+
+Only include dependencies that match specified glob.
+
+`$ npm-check -f babel-*` will only include dependencies starting with 'babel-'.
 
 #### `-E, --save-exact`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -32,6 +32,7 @@ const cli = meow({
           -p, --production      Skip devDependencies.
           -d, --dev-only        Look at devDependencies only (skip dependencies).
           -i, --ignore          Ignore dependencies based on succeeding glob.
+          -f, --filter          Include dependencies based on glob.
           -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
           --specials            List of depcheck specials to include in check for unused dependencies.
           --no-color            Force or disable color output.
@@ -52,7 +53,8 @@ const cli = meow({
             p: 'production',
             d: 'dev-only',
             E: 'save-exact',
-            i: 'ignore'
+            i: 'ignore',
+            f: 'filter'
         },
         default: {
             dir: pkgDir.sync() || process.cwd(),
@@ -73,7 +75,8 @@ const cli = meow({
         ],
         string: [
             'ignore',
-            'specials'
+            'specials',
+            'filter'
         ]
     });
 
@@ -91,7 +94,8 @@ const options = {
     installer: process.env.NPM_CHECK_INSTALLER || 'auto',
     debug: cli.flags.debug,
     spinner: cli.flags.spinner,
-    ignore: cli.flags.ignore
+    ignore: cli.flags.ignore,
+    filter: cli.flags.filter
 };
 
 if (options.debug) {

--- a/lib/in/create-package-summary.js
+++ b/lib/in/create-package-summary.js
@@ -41,6 +41,16 @@ function createPackageSummary(moduleName, currentState) {
         }
     }
 
+    // If --filter is defined, only include specified package globs
+    const filter = currentState.get('filter');
+    if (filter) {
+        const filterMatch = Array.isArray(filter) ? filter.some(filteredModule => minimatch(moduleName, filteredModule)) : minimatch(moduleName, filter);
+
+        if (!filterMatch) {
+            return false;
+        }
+    }
+
     const unusedDependencies = currentState.get('unusedDependencies');
     const missingFromPackageJson = currentState.get('missingFromPackageJson');
 

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -20,6 +20,7 @@ const defaultOptions = {
     spinner: false,
     installer: 'npm',
     ignore: [],
+    filter: [],
 
     globalPackages: {},
     cwdPackageJson: {devDependencies: {}, dependencies: {}},


### PR DESCRIPTION
This is essentially the opposite of ignore. I wanted the ability to only update packages that are prefixed with my company's scope. 

For example: 

```bash
npm-check -y -f '@myorg/*'
```

will automatically bring all the packages prefixed with `@myorg/` up to date. I have this working locally and it is working quite nicely 🎉 it even supports chaining `filter` with `ignore` rules: 

```bash
npm-check -y -f '@myorg/*' -i @myorg/dont-update-me
```