### PR TITLE
adding ability to use package.json version in comparison

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -52,7 +52,8 @@ const cli = meow({
             p: 'production',
             d: 'dev-only',
             E: 'save-exact',
-            i: 'ignore'
+            i: 'ignore',
+            P: 'package-version'
         },
         default: {
             dir: pkgDir.sync() || process.cwd(),
@@ -69,7 +70,8 @@ const cli = meow({
             'save-exact',
             'color',
             'emoji',
-            'spinner'
+            'spinner',
+            'package-version'
         ],
         string: [
             'ignore',
@@ -91,7 +93,8 @@ const options = {
     installer: process.env.NPM_CHECK_INSTALLER || 'auto',
     debug: cli.flags.debug,
     spinner: cli.flags.spinner,
-    ignore: cli.flags.ignore
+    ignore: cli.flags.ignore,
+    packageVersion: cli.flags.packageVersion
 };
 
 if (options.debug) {

--- a/lib/in/create-package-summary.js
+++ b/lib/in/create-package-summary.js
@@ -62,7 +62,12 @@ function createPackageSummary(moduleName, currentState) {
 
             const versionWanted = semver.maxSatisfying(versions, packageJsonVersion);
 
-            const versionToUse = installedVersion || versionWanted;
+            let  versionToUse = installedVersion || versionWanted;
+
+            if (currentState.get('packageVersion')) {
+              versionToUse = packageJsonVersion.replace(/^[^~]/, '');
+            }
+
             const usingNonSemver = semver.valid(latest) && semver.lt(latest, '1.0.0-pre');
 
             const bump = semver.valid(latest) &&

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -20,6 +20,7 @@ const defaultOptions = {
     spinner: false,
     installer: 'npm',
     ignore: [],
+    packageVersion: false,
 
     globalPackages: {},
     cwdPackageJson: {devDependencies: {}, dependencies: {}},


### PR DESCRIPTION
This adds the functionality to allow you to update packages not based on what is currently installed in `node_modules`, but instead based on what is currently defined in the package.json.

### Scenario:

I have just cloned a project that has `"@myorg/common-dep": "^1.0.4"` defined in the package.json. The **latest** version of `@myorg/common-dep` that has been published is `v1.23.4` and because we are using `^` in the package.json npm will install `v1.23.4` for me (which is what I expect).

Now if I run `npm-check -y` nothing will happen. This is because my installed version (in `node_modules`) is currently the same version as the latest. This is potentially unexpected behaviour but it is a perfectly reasonable architectural decision to make 👍 

This PR caters for the case where someone might want to update the package.json to the latest even though they might have the latest version installed locally. One reason for that is potentially `v1.23.3` has a security bug in it and they want to make sure that anyone who has the project checked out locally updates their package ASAP and make sure that it is **explicit** in the package.json and not just something that the package-lock.json or yarn.lock files communicated 👍 