### PR TITLE
Use more recent Node versions on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-  - nodejs_version: 7
-  - nodejs_version: 6
-  - nodejs_version: 4
+  - nodejs_version: 12
+  - nodejs_version: 10
+  - nodejs_version: 8
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
Note that all versions below 8 [are not supported anymore](https://nodejs.org/en/about/releases/). See also #351 for Travis CI.