### PR TITLE
fix bug in read-package-json.js, use readFileSync instead of require

### DIFF
--- a/lib/in/read-package-json.js
+++ b/lib/in/read-package-json.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const extend = require('xtend');
+const fs = require('fs');
 
 function readPackageJson(filename) {
     let pkg;
     let error;
     try {
-        pkg = require(filename);
+        pkg = JSON.parse(fs.readFileSync(filename, 'utf8'));
     } catch (e) {
         if (e.code === 'MODULE_NOT_FOUND') {
             error = new Error(`A package.json was not found at ${filename}`);

--- a/lib/in/read-package-json.js
+++ b/lib/in/read-package-json.js
@@ -9,10 +9,12 @@ function readPackageJson(filename) {
     try {
         pkg = JSON.parse(fs.readFileSync(filename, 'utf8'));
     } catch (e) {
-        if (e.code === 'MODULE_NOT_FOUND') {
+        if (e.code === 'ENOENT') {
             error = new Error(`A package.json was not found at ${filename}`);
-        } else {
+        } else if(e instanceof SyntaxError) {
             error = new Error(`A package.json was found at ${filename}, but it is not valid.`);
+        } else {
+            error = e;
         }
     }
     return extend({devDependencies: {}, dependencies: {}, error: error}, pkg)


### PR DESCRIPTION
when use npmCheck to get real-time dependencies info like codes below, it turns out that can't get updated info
it seems that can't read correct package.json info, because :

[ pkg = require(filename);](https://github.com/dylang/npm-check/blob/f569c7d224cd640b05128cd6fbd9a95307408ad0/lib/in/read-package-json.js#L9)

```
const npmCheck = require('npm-check');
 
npmCheck(options)
  .then(currentState => console.log(currentState.get('packages')));



// do something like yarn add package will change package.json



npmCheck(options)
  .then(currentState => console.log(currentState.get('packages')));