### PR TITLE
fix security vulnerability in lodash package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3308,9 +3308,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.assign": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "globby": "^4.0.0",
     "inquirer": "^0.12.0",
     "is-ci": "^1.0.8",
-    "lodash": "^4.7.0",
+    "lodash": "^4.17.15",
     "meow": "^3.7.0",
     "minimatch": "^3.0.2",
     "node-emoji": "^1.0.3",


### PR DESCRIPTION
Lodash 4.7.0 has several security vulnerabilities, for example it is prone to prototype pollution an also ReDOS attack, the list of all vulnerabilities can be seen [here](https://snyk.io/test/npm/lodash/4.7.0).

This small patch fixes this issue.