### PR TITLE
implemented ability to save JSON report to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Options
   -d, --dev-only        Look at devDependencies only (skip dependencies).
   -i, --ignore          Ignore dependencies based on succeeding glob.
   -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
+  --json                Save Json report to file
   --specials            List of depcheck specials to include in check for unused dependencies.
   --no-color            Force or disable color output.
   --no-emoji            Remove emoji support. No emoji in default in CI environments.
@@ -149,6 +150,12 @@ Ignore dependencies that match specified glob.
 Install packages using `--save-exact`, meaning exact versions will be saved in package.json.
 
 Applies to both `dependencies` and `devDependencies`.
+
+#### `--json`
+
+Save Json report to file.
+
+`$ npm-check --json=/home/user/report.json` will save JSON report to `/home/user/report.json`.
 
 #### `--specials`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,6 +8,7 @@ const createCallsiteRecord = require('callsite-record');
 const pkg = require('../package.json');
 const npmCheck = require('./index');
 const staticOutput = require('./out/static-output');
+const jsonOutput = require('./out/json-output');
 const interactiveUpdate = require('./out/interactive-update');
 const updateAll = require('./out/update-all');
 const debug = require('./state/debug');
@@ -33,6 +34,7 @@ const cli = meow({
           -d, --dev-only        Look at devDependencies only (skip dependencies).
           -i, --ignore          Ignore dependencies based on succeeding glob.
           -E, --save-exact      Save exact version (x.y.z) instead of caret (^x.y.z) in package.json.
+          --json                Save Json report to file.
           --specials            List of depcheck specials to include in check for unused dependencies.
           --no-color            Force or disable color output.
           --no-emoji            Remove emoji support. No emoji in default in CI environments.
@@ -73,6 +75,7 @@ const cli = meow({
         ],
         string: [
             'ignore',
+            'json',
             'specials'
         ]
     });
@@ -86,6 +89,7 @@ const options = {
     ignoreDev: cli.flags.production,
     devOnly: cli.flags.devOnly,
     saveExact: cli.flags.saveExact,
+    json: cli.flags.json,
     specials: cli.flags.specials,
     emoji: cli.flags.emoji,
     installer: process.env.NPM_CHECK_INSTALLER || 'auto',
@@ -118,7 +122,9 @@ Promise.resolve()
         if (options.update) {
             return interactiveUpdate(currentState);
         }
-
+        if (options.json) {
+            return jsonOutput(currentState, options.json);
+        }
         return staticOutput(currentState);
     })
     .catch(err => {

--- a/lib/out/json-output.js
+++ b/lib/out/json-output.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const chalk = require('chalk');
+const _ = require('lodash');
+const fs = require("fs");
+
+function outputJSON(currentState, filename) {
+    const packages = currentState.get('packages');
+    fs.writeFileSync(filename, JSON.stringify(packages, null, 4));
+    console.log(`Report saved to ${filename}`)
+    process.exitCode = 0;
+}
+
+module.exports = outputJSON;

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -14,6 +14,7 @@ const defaultOptions = {
     devOnly: false,
     forceColor: false,
     saveExact: false,
+    json: '',
     specials: '',
     debug: false,
     emoji: true,


### PR DESCRIPTION
Fixes: #257 

`--json` flag will save json report to file.
Example `$ npm-check --json=/home/user/report.json` will save JSON report to `/home/user/report.json`

Sample report:
```
[
    {
        "moduleName": "babel-runtime",
        "homepage": "https://github.com/babel/babel",
        "latest": "6.26.0",
        "installed": "6.26.0",
        "isInstalled": true,
        "notInstalled": false,
        "packageWanted": "6.26.0",
        "packageJson": "^6.6.1",
        "devDependency": false,
        "mismatch": false,
        "semverValid": "6.26.0",
        "easyUpgrade": true,
        "bump": null,
        "unused": false
    }
]
```