### PR TITLE
Include `./index.d.ts` in the package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "files": [
     "bin",
     "lib",
-    "lib-es5"
+    "lib-es5",
+    "index.d.ts"
   ],
   "dependencies": {
     "callsite-record": "^4.1.4",


### PR DESCRIPTION
The `package.json` declares that this package ships with typings, but the `index.d.ts` file is not included in the shipped package.

This PR adds that file to the shipped package.