### PR TITLE
Update README.md Alert to CLI limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ npm install -g npm-check
 ```bash
 npm-check
 ```
+In Windows, use cmd or powershell CLIs
 
 <img width="882" alt="npm-check" src="https://cloud.githubusercontent.com/assets/51505/9569919/99c2412a-4f48-11e5-8c65-e9b6530ee991.png">
 


### PR DESCRIPTION
I couldn't run npm-check - which gave me a "Cannot find... :line 8" error.

The scripts require powershell or cmd. Swithching from BASH to CMD solved my problem.

I see several issues flagged for problems running in windows.

This is a temporary patch/hack rather than a fix. A fix would accomodate mor cli's and alert user at runtime.