### PR TITLE
Fall back to empty string when registry/package error not available

### DIFF
--- a/lib/out/interactive-update.js
+++ b/lib/out/interactive-update.js
@@ -48,7 +48,7 @@ function label(pkg) {
         installed,
         installed && '❯',
         chalk.bold(pkg.latest || ''),
-        pkg.latest ? homepage : pkg.regError || pkg.pkgError
+        pkg.latest ? homepage : pkg.regError || pkg.pkgError || ''
     ];
 }
 


### PR DESCRIPTION
There's a weird package in my package.json that breaks this tool. It appears that all of `pkg.latest`, `pkg.regError`, and `pkg.pkgError` are either falsey or `undefined`. This causes the `label` function to return an array with `undefined` as the last item for this package. Then, when the packages are passed to the `text-table` library during an interactive update, the library's `dotindex` function chokes when it attempts to ready the `length` of the undefined value.
Falling back to an empty string seems ok here, but I can adjust so that it's a more helpful string instead (e.g. "Unable to acquire package details. Check the value for `${name}` in your package.json").
Here's the (slightly redacted) cli output from when I encountered the error (I had to change `console.log(error.message)` to `console.log(error)` in `lib/cli.js` to be able to see the full stack of the `Cannot read properties of undefined (reading 'length')` error):
```log
$ npm-check -su --debug
[npm-check] debug
cli.flags {
  skipUnused: true,
  update: true,
  debug: true,
  updateAll: false,
  global: false,
  production: false,
  devOnly: false,
  saveExact: false,
  color: false,
  emoji: true,
  spinner: true
}
===============================
[npm-check] debug
cli.input []
===============================
[npm-check] debug
set key spinner to value true
===============================
[npm-check] debug
set key ignore to value undefined
===============================
[npm-check] debug
set key cwdPackageJson to value {
  !!! OMITTED !!!
}
===============================
[npm-check] debug
set key cwd to value F:\my-project
===============================
[npm-check] debug
set key unusedDependencies to value [ undefined, undefined ]
===============================
[npm-check] debug
set key missingFromPackageJson to value {}
===============================
⠇ Checking npm registries for updated packages.[npm-check] debug
set key packages to value [
  !!! OMITTED !!!
]
===============================
[npm-check] debug
current state {
  !!! OMITTED !!!
}
===============================
packages [
  !!! OMITTED !!!
]
TypeError: Cannot read properties of undefined (reading 'length')
    at dotindex (C:\Users\david\AppData\Roaming\nvm\v20.11.1\node_modules\npm-check\node_modules\text-table\index.js:59:32)
    at C:\Users\david\AppData\Roaming\nvm\v20.11.1\node_modules\npm-check\node_modules\text-table\index.js:11:21
    at Array.forEach (<anonymous>)
    at forEach (C:\Users\david\AppData\Roaming\nvm\v20.11.1\node_modules\npm-check\node_modules\text-table\index.js:73:31)
    at C:\Users\david\AppData\Roaming\nvm\v20.11.1\node_modules\npm-check\node_modules\text-table\index.js:10:9
    at Array.reduce (<anonymous>)
    at reduce (C:\Users\david\AppData\Roaming\nvm\v20.11.1\node_modules\npm-check\node_modules\text-table\index.js:63:30)
    at module.exports (C:\Users\david\AppData\Roaming\nvm\v20.11.1\node_modules\npm-check\node_modules\text-table\index.js:9:20)
    at createChoices (C:\Users\david\AppData\Roaming\nvm\v20.11.1\node_modules\npm-check\lib\out\interactive-update.js:83:29)
    at C:\Users\david\AppData\Roaming\nvm\v20.11.1\node_modules\npm-check\lib\out\interactive-update.js:114:51
TypeError: Cannot read properties of null (reading 'renderSync')
    at C:\Users\david\AppData\Roaming\nvm\v20.11.1\node_modules\npm-check\lib\cli.js:151:52
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```